### PR TITLE
feat: add dark theme support for the app

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -125,9 +125,11 @@ class MyApp extends StatelessWidget {
         BlocProvider(create: (_) => captionTextStyleCubit),
         BlocProvider(create: (_) => overlineTextStyleCubit),
       ],
-      child: const MaterialApp(
+      child: MaterialApp(
         title: 'Appainter',
-        home: HomePage(),
+        theme: ThemeData(),
+        darkTheme: ThemeData.dark(),
+        home: const HomePage(),
       ),
     );
   }

--- a/lib/home/views/home_page.dart
+++ b/lib/home/views/home_page.dart
@@ -17,6 +17,8 @@ class HomePage extends StatefulWidget {
 
 class _HomePageState extends State<HomePage> {
   static const _sdkVersion = '2.8.1';
+  static final _backgroundColorDark = Colors.grey[850]!;
+  static final _backgroundColorLight = Colors.grey[200]!;
 
   @override
   void initState() {
@@ -27,7 +29,9 @@ class _HomePageState extends State<HomePage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.grey[200],
+      backgroundColor: Theme.of(context).brightness == Brightness.dark
+          ? _backgroundColorDark
+          : _backgroundColorLight,
       appBar: AppBar(
         title: const Text('Appainter'),
         centerTitle: false,
@@ -56,7 +60,9 @@ class _HomePageState extends State<HomePage> {
   SnackBar _buildSdkSnackBar() {
     return SnackBar(
       behavior: SnackBarBehavior.floating,
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).brightness == Brightness.dark
+          ? _backgroundColorDark
+          : _backgroundColorLight,
       duration: const Duration(seconds: 7),
       margin: EdgeInsets.only(
         left: kMargin,
@@ -223,7 +229,7 @@ class _EditModeTabBar extends StatelessWidget {
           key: Key('homePage_editModeTabBar_$text'),
           child: Text(
             text,
-            style: const TextStyle(color: Colors.black),
+            style: Theme.of(context).textTheme.subtitle2,
           ),
         );
       }).toList(),

--- a/lib/text_theme/views/text_theme_editor.dart
+++ b/lib/text_theme/views/text_theme_editor.dart
@@ -14,7 +14,9 @@ class TextThemeEditor extends ExpansionPanelItem {
     return Padding(
       padding: kPaddingAll,
       child: MyExpansionPanelList(
-        color: Colors.grey[100],
+        color: Theme.of(context).brightness == Brightness.dark
+            ? Colors.grey[700]
+            : Colors.grey[100],
         items: const [
           Headline1TextStyleEditor(),
           Headline2TextStyleEditor(),

--- a/lib/theme_preview/views/theme_preview.dart
+++ b/lib/theme_preview/views/theme_preview.dart
@@ -146,44 +146,46 @@ class ThemePreview extends StatelessWidget {
         final theme =
             state.editMode == EditMode.basic ? basicTheme : advancedTheme;
 
-        return DevicePreview(builder: (context) {
-          return MaterialApp(
-            theme: theme,
-            locale: DevicePreview.locale(context),
-            useInheritedMediaQuery: true,
-            home: DefaultTabController(
-              length: _pages.length,
-              child: Scaffold(
-                appBar: AppBar(
-                  title: const Text('Theme Preview'),
-                  actions: [
-                    IconButton(
-                      icon: const Icon(Icons.notifications),
-                      onPressed: () {},
-                    )
-                  ],
-                  bottom: TabBar(
-                    tabs: _pages.map((page) {
-                      return Tab(
-                        icon: Icon(page.icon),
-                        text: page.label,
-                      );
-                    }).toList(),
+        return DevicePreview(
+          builder: (context) {
+            return MaterialApp(
+              theme: theme,
+              locale: DevicePreview.locale(context),
+              useInheritedMediaQuery: true,
+              home: DefaultTabController(
+                length: _pages.length,
+                child: Scaffold(
+                  appBar: AppBar(
+                    title: const Text('Theme Preview'),
+                    actions: [
+                      IconButton(
+                        icon: const Icon(Icons.notifications),
+                        onPressed: () {},
+                      )
+                    ],
+                    bottom: TabBar(
+                      tabs: _pages.map((page) {
+                        return Tab(
+                          icon: Icon(page.icon),
+                          text: page.label,
+                        );
+                      }).toList(),
+                    ),
                   ),
+                  drawer: _Drawer(),
+                  body: TabBarView(
+                    children: _pages,
+                  ),
+                  floatingActionButton: FloatingActionButton(
+                    onPressed: () {},
+                    child: const Icon(Icons.add),
+                  ),
+                  bottomNavigationBar: _BottomNavigationBar(),
                 ),
-                drawer: _Drawer(),
-                body: TabBarView(
-                  children: _pages,
-                ),
-                floatingActionButton: FloatingActionButton(
-                  onPressed: () {},
-                  child: const Icon(Icons.add),
-                ),
-                bottomNavigationBar: _BottomNavigationBar(),
               ),
-            ),
-          );
-        });
+            );
+          },
+        );
       },
     );
   }

--- a/lib/widgets/cards/card.dart
+++ b/lib/widgets/cards/card.dart
@@ -4,20 +4,22 @@ import 'package:appainter/common/consts.dart';
 class MyCard extends StatelessWidget {
   final Widget child;
   final EdgeInsets padding;
-  final Color color;
+  final Color? color;
 
-  MyCard({
+  const MyCard({
     Key? key,
     required this.child,
     this.padding = kPaddingAll,
-    Color? color,
-  })  : color = color ?? Colors.grey[50]!,
-        super(key: key);
+    this.color,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
+    final fllbackColor = Theme.of(context).brightness == Brightness.dark
+        ? Colors.grey[800]
+        : Colors.grey[50];
     return Card(
-      color: color,
+      color: color ?? fllbackColor,
       child: Padding(
         padding: padding,
         child: child,

--- a/lib/widgets/cards/material_state_property_card.dart
+++ b/lib/widgets/cards/material_state_property_card.dart
@@ -28,7 +28,9 @@ class MaterialStatePropertyCard<T> extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MyCard(
-      color: Colors.grey[100],
+      color: Theme.of(context).brightness == Brightness.dark
+          ? Colors.grey[700]
+          : Colors.grey[100],
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [

--- a/lib/widgets/text_form_field.dart
+++ b/lib/widgets/text_form_field.dart
@@ -23,7 +23,9 @@ class MyTextFormField extends StatelessWidget {
       ],
       decoration: InputDecoration(
         filled: true,
-        fillColor: Colors.grey[200],
+        fillColor: Theme.of(context).brightness == Brightness.dark
+            ? Colors.grey[850]
+            : Colors.grey[200],
         labelText: labelText,
       ),
       onChanged: onChanged,


### PR DESCRIPTION
- Light or dark theme will be used depending on the system preference
- Dark background doesn't seem to be working on device preview, raised an issue https://github.com/aloisdeniel/flutter_device_preview/issues/162