### PR TITLE
feat: refactor font picker with dropdown search

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -21,8 +21,13 @@ import 'package:appainter/text_theme/text_theme.dart';
 
 class MyApp extends StatelessWidget {
   final HomeRepository homeRepo;
+  final TextThemeRepository textThemeRepo;
 
-  const MyApp({Key? key, required this.homeRepo}) : super(key: key);
+  const MyApp({
+    Key? key,
+    required this.homeRepo,
+    required this.textThemeRepo,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -91,41 +96,44 @@ class MyApp extends StatelessWidget {
       textThemeCubit: textThemeCubit,
     );
 
-    return MultiBlocProvider(
-      providers: [
-        BlocProvider(create: (_) => HomeCubit(homeRepo, advancedThemeCubit)),
-        BlocProvider(create: (_) => BasicThemeCubit()),
-        BlocProvider(create: (_) => advancedThemeCubit),
-        BlocProvider(create: (_) => colorThemeCubit),
-        BlocProvider(create: (_) => appBarThemeCubit),
-        BlocProvider(create: (_) => tabBarThemeCubit),
-        BlocProvider(create: (_) => bottomNavigationBarThemeCubit),
-        BlocProvider(create: (_) => floatingActionButtonThemeCubit),
-        BlocProvider(create: (_) => elevatedButtonThemeCubit),
-        BlocProvider(create: (_) => outlinedButtonThemeCubit),
-        BlocProvider(create: (_) => textButtonThemeCubit),
-        BlocProvider(create: (_) => iconThemeCubit),
-        BlocProvider(create: (_) => inputDecorationThemeCubit),
-        BlocProvider(create: (_) => switchThemeCubit),
-        BlocProvider(create: (_) => checkboxThemeCubit),
-        BlocProvider(create: (_) => radioThemeCubit),
-        BlocProvider(create: (_) => sliderThemeCubit),
-        BlocProvider(create: (_) => textThemeCubit),
-        BlocProvider(create: (_) => headline1TextStyleCubit),
-        BlocProvider(create: (_) => headline2TextStyleCubit),
-        BlocProvider(create: (_) => headline3TextStyleCubit),
-        BlocProvider(create: (_) => headline4TextStyleCubit),
-        BlocProvider(create: (_) => headline5TextStyleCubit),
-        BlocProvider(create: (_) => headline6TextStyleCubit),
-        BlocProvider(create: (_) => subtitle1TextStyleCubit),
-        BlocProvider(create: (_) => subtitle2TextStyleCubit),
-        BlocProvider(create: (_) => bodyText1TextStyleCubit),
-        BlocProvider(create: (_) => bodyText2TextStyleCubit),
-        BlocProvider(create: (_) => buttonTextStyleCubit),
-        BlocProvider(create: (_) => captionTextStyleCubit),
-        BlocProvider(create: (_) => overlineTextStyleCubit),
-      ],
-      child: const _MaterialApp(),
+    return RepositoryProvider.value(
+      value: textThemeRepo,
+      child: MultiBlocProvider(
+        providers: [
+          BlocProvider(create: (_) => HomeCubit(homeRepo, advancedThemeCubit)),
+          BlocProvider(create: (_) => BasicThemeCubit()),
+          BlocProvider(create: (_) => advancedThemeCubit),
+          BlocProvider(create: (_) => colorThemeCubit),
+          BlocProvider(create: (_) => appBarThemeCubit),
+          BlocProvider(create: (_) => tabBarThemeCubit),
+          BlocProvider(create: (_) => bottomNavigationBarThemeCubit),
+          BlocProvider(create: (_) => floatingActionButtonThemeCubit),
+          BlocProvider(create: (_) => elevatedButtonThemeCubit),
+          BlocProvider(create: (_) => outlinedButtonThemeCubit),
+          BlocProvider(create: (_) => textButtonThemeCubit),
+          BlocProvider(create: (_) => iconThemeCubit),
+          BlocProvider(create: (_) => inputDecorationThemeCubit),
+          BlocProvider(create: (_) => switchThemeCubit),
+          BlocProvider(create: (_) => checkboxThemeCubit),
+          BlocProvider(create: (_) => radioThemeCubit),
+          BlocProvider(create: (_) => sliderThemeCubit),
+          BlocProvider(create: (_) => textThemeCubit),
+          BlocProvider(create: (_) => headline1TextStyleCubit),
+          BlocProvider(create: (_) => headline2TextStyleCubit),
+          BlocProvider(create: (_) => headline3TextStyleCubit),
+          BlocProvider(create: (_) => headline4TextStyleCubit),
+          BlocProvider(create: (_) => headline5TextStyleCubit),
+          BlocProvider(create: (_) => headline6TextStyleCubit),
+          BlocProvider(create: (_) => subtitle1TextStyleCubit),
+          BlocProvider(create: (_) => subtitle2TextStyleCubit),
+          BlocProvider(create: (_) => bodyText1TextStyleCubit),
+          BlocProvider(create: (_) => bodyText2TextStyleCubit),
+          BlocProvider(create: (_) => buttonTextStyleCubit),
+          BlocProvider(create: (_) => captionTextStyleCubit),
+          BlocProvider(create: (_) => overlineTextStyleCubit),
+        ],
+        child: const _MaterialApp(),
+      ),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:appainter/text_theme/text_theme.dart';
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
@@ -13,6 +14,7 @@ void main() {
   BlocOverrides.runZoned(
     () => runApp(MyApp(
       homeRepo: HomeRepository(),
+      textThemeRepo: TextThemeRepository(),
     )),
     blocObserver: MyBlocObserver(),
   );

--- a/lib/services/widget_service.dart
+++ b/lib/services/widget_service.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flex_color_picker/flex_color_picker.dart';
-import 'package:google_fonts/google_fonts.dart';
 
 class WidgetService {
   static Future<void> showColorPicker({
@@ -52,47 +51,6 @@ class WidgetService {
       constraints: const BoxConstraints(
         minHeight: 550,
         maxWidth: 450,
-      ),
-    );
-  }
-
-  static Future<String?> showFontPicker({
-    required BuildContext context,
-  }) async {
-    final fonts = GoogleFonts.asMap().entries.toList();
-    final size = MediaQuery.of(context).size;
-
-    return await showDialog<String>(
-      context: context,
-      builder: (BuildContext context) => AlertDialog(
-        title: const Text('Select font'),
-        content: SizedBox(
-          width: size.width * 0.3,
-          height: size.height * 0.7,
-          child: ListView.separated(
-            shrinkWrap: true,
-            itemCount: fonts.length,
-            itemBuilder: (context, index) {
-              final entry = fonts[index];
-              final fontFamily = entry.key;
-
-              return ListTile(
-                key: Key('fontPicker_$fontFamily'),
-                title: Text(fontFamily, style: entry.value()),
-                onTap: () => Navigator.of(context).pop(fontFamily),
-              );
-            },
-            separatorBuilder: (context, index) {
-              return Container();
-            },
-          ),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(),
-            child: const Text('Cancel'),
-          ),
-        ],
       ),
     );
   }

--- a/lib/text_theme/constants.dart
+++ b/lib/text_theme/constants.dart
@@ -1,0 +1,2 @@
+const kDefaultFontFamily = 'Roboto';
+const kMaxFontSearchResults = 10;

--- a/lib/text_theme/cubits/text_theme_state.dart
+++ b/lib/text_theme/cubits/text_theme_state.dart
@@ -4,7 +4,7 @@ part of 'text_theme_cubit.dart';
 class TextThemeState extends Equatable {
   final String fontFamily;
 
-  const TextThemeState({this.fontFamily = 'Roboto'});
+  const TextThemeState({this.fontFamily = kDefaultFontFamily});
 
   @override
   List<Object> get props => [fontFamily];

--- a/lib/text_theme/models/font_data.dart
+++ b/lib/text_theme/models/font_data.dart
@@ -1,0 +1,19 @@
+import 'package:appainter/text_theme/text_theme.dart';
+import 'package:equatable/equatable.dart';
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+class FontData extends Equatable {
+  final String family;
+  final TextStyle style;
+
+  const FontData(this.family, this.style);
+
+  factory FontData.defaultFontData() {
+    final style = GoogleFonts.getFont(kDefaultFontFamily);
+    return FontData(kDefaultFontFamily, style);
+  }
+
+  @override
+  List<Object> get props => [family, style];
+}

--- a/lib/text_theme/models/models.dart
+++ b/lib/text_theme/models/models.dart
@@ -1,0 +1,1 @@
+export 'font_data.dart';

--- a/lib/text_theme/text_theme.dart
+++ b/lib/text_theme/text_theme.dart
@@ -1,2 +1,6 @@
 export 'cubits/cubits.dart';
 export 'views/views.dart';
+export 'text_theme_repository.dart';
+export 'models/models.dart';
+export 'constants.dart';
+export 'widgets/widgets.dart';

--- a/lib/text_theme/text_theme_repository.dart
+++ b/lib/text_theme/text_theme_repository.dart
@@ -1,0 +1,15 @@
+import 'package:appainter/text_theme/text_theme.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+class TextThemeRepository {
+  List<FontData> searchFonts(String query) {
+    return GoogleFonts.asMap()
+        .entries
+        .where(
+          (entry) => entry.key.toLowerCase().contains(query.toLowerCase()),
+        )
+        .map((entry) => FontData(entry.key, entry.value()))
+        .take(kMaxFontSearchResults)
+        .toList();
+  }
+}

--- a/lib/text_theme/views/text_theme_editor.dart
+++ b/lib/text_theme/views/text_theme_editor.dart
@@ -1,11 +1,6 @@
-import 'package:appainter/services/widget_service.dart';
-import 'package:flutter/material.dart';
 import 'package:appainter/text_theme/text_theme.dart';
 import 'package:appainter/widgets/widgets.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
-
-final _colorDark = Colors.grey[700];
-final _colorLight = Colors.grey[100];
+import 'package:flutter/material.dart';
 
 class TextThemeEditor extends ExpansionPanelItem {
   const TextThemeEditor({Key? key}) : super(key: key);
@@ -20,8 +15,8 @@ class TextThemeEditor extends ExpansionPanelItem {
         const FontPicker(),
         MyExpansionPanelList(
           color: Theme.of(context).brightness == Brightness.dark
-              ? _colorDark
-              : _colorLight,
+              ? Colors.grey[700]
+              : Colors.grey[100],
           items: const [
             Headline1TextStyleEditor(),
             Headline2TextStyleEditor(),
@@ -40,42 +35,6 @@ class TextThemeEditor extends ExpansionPanelItem {
         ),
       ],
     );
-  }
-}
-
-@visibleForTesting
-class FontPicker extends StatelessWidget {
-  const FontPicker({Key? key}) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    return MyCard(
-      key: const Key('textThemeEditor_fontPicker'),
-      color: Theme.of(context).brightness == Brightness.dark
-          ? _colorDark
-          : _colorLight,
-      margin: EdgeInsets.zero,
-      onTap: () => _onTap(context),
-      child: BlocBuilder<TextThemeCubit, TextThemeState>(
-        buildWhen: (previous, current) {
-          return previous.fontFamily != current.fontFamily;
-        },
-        builder: (context, state) {
-          return MyListTile(
-            key: const Key('textThemeEditor_fontPicker_listTile'),
-            title: 'Font Family',
-            trailing: Text(state.fontFamily),
-          );
-        },
-      ),
-    );
-  }
-
-  Future<void> _onTap(BuildContext context) async {
-    final fontFamily = await WidgetService.showFontPicker(context: context);
-    if (fontFamily != null) {
-      context.read<TextThemeCubit>().fontFamilyChanged(fontFamily);
-    }
   }
 }
 

--- a/lib/text_theme/widgets/font_picker.dart
+++ b/lib/text_theme/widgets/font_picker.dart
@@ -1,0 +1,52 @@
+import 'package:appainter/text_theme/text_theme.dart';
+import 'package:dropdown_search/dropdown_search.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class FontPicker extends StatelessWidget {
+  const FontPicker({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return DropdownSearch<FontData>(
+      key: const Key('fontPicker'),
+      mode: Mode.MENU,
+      showSearchBox: true,
+      isFilteredOnline: true,
+      selectedItem: FontData.defaultFontData(),
+      dropdownSearchDecoration: const InputDecoration(labelText: 'Font family'),
+      itemAsString: (item) => item?.family ?? kDefaultFontFamily,
+      searchFieldProps: TextFieldProps(
+        decoration: const InputDecoration(
+          labelText: 'Search for fonts',
+          helperText: 'Fonts are sourced from Google Fonts, '
+              'only the top $kMaxFontSearchResults fonts are shown',
+          helperMaxLines: 2,
+          border: OutlineInputBorder(),
+        ),
+      ),
+      popupItemBuilder: (context, item, isSelected) {
+        return ListTile(
+          key: Key('fontPicker_${item.family}'),
+          title: Text(item.family, style: item.style),
+        );
+      },
+      onFind: (query) => _onFind(context, query),
+      onChanged: (data) => _onChanged(context, data),
+    );
+  }
+
+  Future<List<FontData>> _onFind(BuildContext context, String? query) {
+    return Future.value(
+      query != null
+          ? context.read<TextThemeRepository>().searchFonts(query)
+          : [],
+    );
+  }
+
+  void _onChanged(BuildContext context, FontData? data) {
+    if (data != null) {
+      context.read<TextThemeCubit>().fontFamilyChanged(data.family);
+    }
+  }
+}

--- a/lib/text_theme/widgets/widgets.dart
+++ b/lib/text_theme/widgets/widgets.dart
@@ -1,0 +1,1 @@
+export 'font_picker.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -253,6 +253,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.4"
+  dropdown_search:
+    dependency: "direct main"
+    description:
+      name: dropdown_search
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
   enum_to_string:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   cupertino_icons: ^1.0.0
   device_preview: ^1.0.0
   dio: ^4.0.0
+  dropdown_search: ^2.0.1
   enum_to_string: ^2.0.1
   equatable: ^2.0.0
   expandable: ^5.0.1

--- a/test/text_theme/text_theme_repository_test.dart
+++ b/test/text_theme/text_theme_repository_test.dart
@@ -1,0 +1,24 @@
+import 'package:appainter/text_theme/text_theme.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+void main() {
+  final expectedStyle = GoogleFonts.getFont('ABeeZee');
+  late TextThemeRepository repo;
+
+  setUp(() {
+    repo = TextThemeRepository();
+  });
+
+  for (var query in ['ABeeZee', 'abeezee']) {
+    test('search fonts should return correct results for query $query', () {
+      final results = repo.searchFonts(query);
+      expect(results, equals([FontData('ABeeZee', expectedStyle)]));
+    });
+  }
+
+  test('search fonts should return empty results', () {
+    final results = repo.searchFonts('clearlyDoesNotExist');
+    expect(results, equals([]));
+  });
+}

--- a/test/text_theme/widgets/font_picker_test.dart
+++ b/test/text_theme/widgets/font_picker_test.dart
@@ -24,27 +24,25 @@ void main() {
     );
 
     await tester.pumpWidget(
-      BlocProvider.value(
-        value: cubit,
-        child: const MaterialApp(
-          home: FontPicker(),
+      RepositoryProvider(
+        create: (context) => TextThemeRepository(),
+        child: BlocProvider.value(
+          value: cubit,
+          child: const MaterialApp(
+            home: Scaffold(
+              body: FontPicker(),
+            ),
+          ),
         ),
       ),
     );
 
-    await tester.tap(find.byKey(const Key('textThemeEditor_fontPicker')));
+    await tester.tap(find.byKey(const Key('fontPicker')));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const Key('fontPicker_$fontFamily')));
     await tester.pumpAndSettle();
 
-    final parentWidget = find.byKey(
-      const Key('textThemeEditor_fontPicker_listTile'),
-    );
-    final widget = find.descendant(
-      of: parentWidget,
-      matching: find.text(fontFamily),
-    );
-    expect(widget, findsOneWidget);
+    expect(find.text(fontFamily), findsOneWidget);
     verify(() => cubit.fontFamilyChanged(fontFamily));
   });
 }


### PR DESCRIPTION
- Existing font picker has a bad scroll performance and hangs the app after scrolling through the list of fonts
- Refactor font picker with [dropdown_search](https://pub.dev/packages/dropdown_search)
  - Add new dependency `dropdown_search`
  - There's a known issue that the space button doesn't work on desktop, but should be fixed in the next release of the package https://github.com/salim-lachdhaf/searchable_dropdown/issues/300
- Close #269 
- Fix #270 

![image](https://user-images.githubusercontent.com/12210067/153734756-6acc3816-d467-4b5e-b460-4273d4805632.png)
