### PR TITLE
fix: cubits to rely on color theme state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,7 +210,7 @@ Temporary Items
 
 ### VisualStudioCode ###
 .vscode/*
-!.vscode/settings.json
+.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -35,15 +35,28 @@ class MyApp extends StatelessWidget {
     final appBarThemeCubit = AppBarThemeCubit();
     final tabBarThemeCubit = TabBarThemeCubit();
     final bottomNavigationBarThemeCubit = BottomNavigationBarThemeCubit();
+
     final floatingActionButtonThemeCubit = FloatingActionButtonThemeCubit();
-    final elevatedButtonThemeCubit = ElevatedButtonThemeCubit();
-    final outlinedButtonThemeCubit = OutlinedButtonThemeCubit();
-    final textButtonThemeCubit = TextButtonThemeCubit();
+    final elevatedButtonThemeCubit = ElevatedButtonThemeCubit(
+      colorThemeCubit: colorThemeCubit,
+    );
+    final outlinedButtonThemeCubit = OutlinedButtonThemeCubit(
+      colorThemeCubit: colorThemeCubit,
+    );
+    final textButtonThemeCubit = TextButtonThemeCubit(
+      colorThemeCubit: colorThemeCubit,
+    );
+
     final iconThemeCubit = IconThemeCubit();
     final inputDecorationThemeCubit = InputDecorationThemeCubit();
-    final switchThemeCubit = SwitchThemeCubit();
-    final checkboxThemeCubit = CheckboxThemeCubit();
-    final radioThemeCubit = RadioThemeCubit();
+
+    final switchThemeCubit = SwitchThemeCubit(
+      colorThemeCubit: colorThemeCubit,
+    );
+    final checkboxThemeCubit = CheckboxThemeCubit(
+      colorThemeCubit: colorThemeCubit,
+    );
+    final radioThemeCubit = RadioThemeCubit(colorThemeCubit: colorThemeCubit);
     final sliderThemeCubit = SliderThemeCubit();
 
     final headline1TextStyleCubit = Headline1TextStyleCubit();

--- a/lib/checkbox_theme/cubit/checkbox_theme_cubit.dart
+++ b/lib/checkbox_theme/cubit/checkbox_theme_cubit.dart
@@ -1,3 +1,4 @@
+import 'package:appainter/color_theme/color_theme.dart';
 import 'package:bloc/bloc.dart';
 import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:equatable/equatable.dart';
@@ -9,7 +10,10 @@ part 'checkbox_theme_cubit.g.dart';
 part 'checkbox_theme_state.dart';
 
 class CheckboxThemeCubit extends Cubit<CheckboxThemeState> {
-  CheckboxThemeCubit() : super(const CheckboxThemeState());
+  final ColorThemeCubit colorThemeCubit;
+
+  CheckboxThemeCubit({required this.colorThemeCubit})
+      : super(const CheckboxThemeState());
 
   final _utils = const SelectionUtils();
 
@@ -95,29 +99,31 @@ class CheckboxThemeCubit extends Cubit<CheckboxThemeState> {
   }
 
   MaterialStateProperty<Color> get _defaultFillColor {
-    final themeData = ThemeData();
+    final colorThemeState = colorThemeCubit.state;
     return MaterialStateProperty.resolveWith((states) {
       if (states.contains(MaterialState.disabled)) {
-        return themeData.disabledColor;
+        return colorThemeState.disabledColor;
       }
       if (states.contains(MaterialState.selected)) {
-        return themeData.toggleableActiveColor;
+        return colorThemeState.toggleableActiveColor;
       }
-      return themeData.unselectedWidgetColor;
+      return colorThemeState.unselectedWidgetColor;
     });
   }
 
   MaterialStateProperty<Color?> get _defaultOverlayColor {
-    final themeData = ThemeData();
+    final colorThemeState = colorThemeCubit.state;
     return MaterialStateProperty.resolveWith((states) {
       if (states.contains(MaterialState.pressed)) {
-        return themeData.toggleableActiveColor.withAlpha(kRadialReactionAlpha);
+        return colorThemeState.toggleableActiveColor.withAlpha(
+          kRadialReactionAlpha,
+        );
       }
       if (states.contains(MaterialState.hovered)) {
-        return themeData.hoverColor;
+        return colorThemeState.hoverColor;
       }
       if (states.contains(MaterialState.focused)) {
-        return themeData.focusColor;
+        return colorThemeState.focusColor;
       }
       return null;
     });

--- a/lib/elevated_button_theme/cubit/elevated_button_theme_cubit.dart
+++ b/lib/elevated_button_theme/cubit/elevated_button_theme_cubit.dart
@@ -1,3 +1,4 @@
+import 'package:appainter/color_theme/color_theme.dart';
 import 'package:bloc/bloc.dart';
 import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:equatable/equatable.dart';
@@ -8,7 +9,10 @@ part 'elevated_button_theme_cubit.g.dart';
 part 'elevated_button_theme_state.dart';
 
 class ElevatedButtonThemeCubit extends Cubit<ElevatedButtonThemeState> {
-  ElevatedButtonThemeCubit() : super(const ElevatedButtonThemeState());
+  final ColorThemeCubit colorThemeCubit;
+
+  ElevatedButtonThemeCubit({required this.colorThemeCubit})
+      : super(const ElevatedButtonThemeState());
 
   final _buttonUtils = const ButtonUtils();
 
@@ -163,15 +167,15 @@ class ElevatedButtonThemeCubit extends Cubit<ElevatedButtonThemeState> {
   }
 
   ButtonStyle _getStyle() {
-    final themeData = ThemeData();
-    final colorScheme = themeData.colorScheme;
+    final colorThemeState = colorThemeCubit.state;
+    final colorScheme = colorThemeState.colorScheme;
 
     return state.theme.style ??
         ElevatedButton.styleFrom(
           primary: colorScheme.primary,
           onPrimary: colorScheme.onPrimary,
           onSurface: colorScheme.onSurface,
-          shadowColor: themeData.shadowColor,
+          shadowColor: colorThemeState.shadowColor,
           elevation: 2,
           minimumSize: const Size(64, 36),
         );

--- a/lib/outlined_button_theme/cubit/outlined_button_theme_cubit.dart
+++ b/lib/outlined_button_theme/cubit/outlined_button_theme_cubit.dart
@@ -1,3 +1,4 @@
+import 'package:appainter/color_theme/color_theme.dart';
 import 'package:bloc/bloc.dart';
 import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:equatable/equatable.dart';
@@ -8,7 +9,10 @@ part 'outlined_button_theme_cubit.g.dart';
 part 'outlined_button_theme_state.dart';
 
 class OutlinedButtonThemeCubit extends Cubit<OutlinedButtonThemeState> {
-  OutlinedButtonThemeCubit() : super(const OutlinedButtonThemeState());
+  final ColorThemeCubit colorThemeCubit;
+
+  OutlinedButtonThemeCubit({required this.colorThemeCubit})
+      : super(const OutlinedButtonThemeState());
 
   final _buttonUtils = const ButtonUtils();
 
@@ -97,15 +101,15 @@ class OutlinedButtonThemeCubit extends Cubit<OutlinedButtonThemeState> {
   }
 
   ButtonStyle _getStyle() {
-    final themeData = ThemeData();
-    final colorScheme = themeData.colorScheme;
+    final colorThemeState = colorThemeCubit.state;
+    final colorScheme = colorThemeState.colorScheme;
 
     return state.theme.style ??
         OutlinedButton.styleFrom(
           primary: colorScheme.primary,
           onSurface: colorScheme.onSurface,
           backgroundColor: Colors.transparent,
-          shadowColor: themeData.shadowColor,
+          shadowColor: colorThemeState.shadowColor,
           elevation: 0,
           minimumSize: const Size(64, 36),
         );

--- a/lib/radio_theme/cubit/radio_theme_cubit.dart
+++ b/lib/radio_theme/cubit/radio_theme_cubit.dart
@@ -1,3 +1,4 @@
+import 'package:appainter/color_theme/color_theme.dart';
 import 'package:bloc/bloc.dart';
 import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:equatable/equatable.dart';
@@ -9,7 +10,10 @@ part 'radio_theme_cubit.g.dart';
 part 'radio_theme_state.dart';
 
 class RadioThemeCubit extends Cubit<RadioThemeState> {
-  RadioThemeCubit() : super(const RadioThemeState());
+  final ColorThemeCubit colorThemeCubit;
+
+  RadioThemeCubit({required this.colorThemeCubit})
+      : super(const RadioThemeState());
 
   final _utils = const SelectionUtils();
 
@@ -86,29 +90,31 @@ class RadioThemeCubit extends Cubit<RadioThemeState> {
   }
 
   MaterialStateProperty<Color> get _defaultFillColor {
-    final themeData = ThemeData();
+    final colorThemeState = colorThemeCubit.state;
     return MaterialStateProperty.resolveWith((states) {
       if (states.contains(MaterialState.disabled)) {
-        return themeData.disabledColor;
+        return colorThemeState.disabledColor;
       }
       if (states.contains(MaterialState.selected)) {
-        return themeData.toggleableActiveColor;
+        return colorThemeState.toggleableActiveColor;
       }
-      return themeData.unselectedWidgetColor;
+      return colorThemeState.unselectedWidgetColor;
     });
   }
 
   MaterialStateProperty<Color?> get _defaultOverlayColor {
-    final themeData = ThemeData();
+    final colorThemeState = colorThemeCubit.state;
     return MaterialStateProperty.resolveWith((states) {
       if (states.contains(MaterialState.pressed)) {
-        return themeData.toggleableActiveColor.withAlpha(kRadialReactionAlpha);
+        return colorThemeState.toggleableActiveColor.withAlpha(
+          kRadialReactionAlpha,
+        );
       }
       if (states.contains(MaterialState.hovered)) {
-        return themeData.hoverColor;
+        return colorThemeState.hoverColor;
       }
       if (states.contains(MaterialState.focused)) {
-        return themeData.focusColor;
+        return colorThemeState.focusColor;
       }
       return null;
     });

--- a/lib/switch_theme/cubit/switch_theme_cubit.dart
+++ b/lib/switch_theme/cubit/switch_theme_cubit.dart
@@ -1,3 +1,4 @@
+import 'package:appainter/color_theme/color_theme.dart';
 import 'package:bloc/bloc.dart';
 import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:equatable/equatable.dart';
@@ -9,7 +10,10 @@ part 'switch_theme_cubit.g.dart';
 part 'switch_theme_state.dart';
 
 class SwitchThemeCubit extends Cubit<SwitchThemeState> {
-  SwitchThemeCubit() : super(const SwitchThemeState());
+  final ColorThemeCubit colorThemeCubit;
+
+  SwitchThemeCubit({required this.colorThemeCubit})
+      : super(const SwitchThemeState());
 
   final _utils = const SelectionUtils();
 
@@ -115,42 +119,44 @@ class SwitchThemeCubit extends Cubit<SwitchThemeState> {
   }
 
   MaterialStateProperty<Color> get _defaultThumbColor {
-    final themeData = ThemeData();
+    final colorThemeState = colorThemeCubit.state;
     return MaterialStateProperty.resolveWith((states) {
       if (states.contains(MaterialState.disabled)) {
         return Colors.grey.shade400;
       }
       if (states.contains(MaterialState.selected)) {
-        return themeData.toggleableActiveColor;
+        return colorThemeState.toggleableActiveColor;
       }
       return Colors.grey.shade50;
     });
   }
 
   MaterialStateProperty<Color> get _defaultTrackColor {
-    final themeData = ThemeData();
+    final colorThemeState = colorThemeCubit.state;
     return MaterialStateProperty.resolveWith((states) {
       if (states.contains(MaterialState.disabled)) {
         return Colors.black12;
       }
       if (states.contains(MaterialState.selected)) {
-        return themeData.toggleableActiveColor.withAlpha(0x80);
+        return colorThemeState.toggleableActiveColor.withAlpha(0x80);
       }
       return const Color(0x52000000);
     });
   }
 
   MaterialStateProperty<Color?> get _defaultOverlayColor {
-    final themeData = ThemeData();
+    final colorThemeState = colorThemeCubit.state;
     return MaterialStateProperty.resolveWith((states) {
       if (states.contains(MaterialState.pressed)) {
-        return themeData.toggleableActiveColor.withAlpha(kRadialReactionAlpha);
+        return colorThemeState.toggleableActiveColor.withAlpha(
+          kRadialReactionAlpha,
+        );
       }
       if (states.contains(MaterialState.hovered)) {
-        return themeData.hoverColor;
+        return colorThemeState.hoverColor;
       }
       if (states.contains(MaterialState.focused)) {
-        return themeData.focusColor;
+        return colorThemeState.focusColor;
       }
       return null;
     });

--- a/lib/text_button_theme/cubit/text_button_theme_cubit.dart
+++ b/lib/text_button_theme/cubit/text_button_theme_cubit.dart
@@ -1,3 +1,4 @@
+import 'package:appainter/color_theme/color_theme.dart';
 import 'package:bloc/bloc.dart';
 import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:equatable/equatable.dart';
@@ -8,7 +9,10 @@ part 'text_button_theme_cubit.g.dart';
 part 'text_button_theme_state.dart';
 
 class TextButtonThemeCubit extends Cubit<TextButtonThemeState> {
-  TextButtonThemeCubit() : super(const TextButtonThemeState());
+  final ColorThemeCubit colorThemeCubit;
+
+  TextButtonThemeCubit({required this.colorThemeCubit})
+      : super(const TextButtonThemeState());
 
   final _buttonUtils = const ButtonUtils();
 
@@ -97,15 +101,15 @@ class TextButtonThemeCubit extends Cubit<TextButtonThemeState> {
   }
 
   ButtonStyle _getButtonStyle() {
-    final themeData = ThemeData();
-    final colorScheme = themeData.colorScheme;
+    final colorThemeState = colorThemeCubit.state;
+    final colorScheme = colorThemeState.colorScheme;
 
     return state.theme.style ??
         TextButton.styleFrom(
           primary: colorScheme.primary,
           onSurface: colorScheme.onSurface,
           backgroundColor: Colors.transparent,
-          shadowColor: themeData.shadowColor,
+          shadowColor: colorThemeState.shadowColor,
           elevation: 0,
           minimumSize: const Size(64, 36),
         );

--- a/test/checkbox_theme/checkbox_theme_cubit_test.dart
+++ b/test/checkbox_theme/checkbox_theme_cubit_test.dart
@@ -1,16 +1,20 @@
 import 'dart:math';
 
+import 'package:appainter/color_theme/color_theme.dart';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:appainter/checkbox_theme/checkbox_theme.dart';
 import 'package:appainter/services/services.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:random_color_scheme/random_color_scheme.dart';
 
+import '../mocks.dart';
 import '../utils.dart';
 
 void main() {
-  late CheckboxThemeCubit cubit;
+  late CheckboxThemeCubit checkboxThemeCubit;
+  late ColorThemeCubit colorThemeCubit;
   late CheckboxThemeData theme;
   late Color color;
   late double doubleValue;
@@ -36,7 +40,10 @@ void main() {
   });
 
   setUp(() {
-    cubit = CheckboxThemeCubit();
+    colorThemeCubit = MockColorThemeCubit();
+    when(() => colorThemeCubit.state).thenReturn(ColorThemeState());
+
+    checkboxThemeCubit = CheckboxThemeCubit(colorThemeCubit: colorThemeCubit);
     color = getRandomColor();
     doubleValue = Random().nextDouble();
   });
@@ -47,7 +54,7 @@ void main() {
       final colorScheme = randomColorSchemeLight(shouldPrint: false);
       theme = ThemeData.from(colorScheme: colorScheme).checkboxTheme;
     },
-    build: () => cubit,
+    build: () => checkboxThemeCubit,
     act: (cubit) => cubit.themeChanged(theme),
     expect: () => [CheckboxThemeState(theme: theme)],
   );
@@ -55,7 +62,7 @@ void main() {
   group('test fill colors', () {
     blocTest<CheckboxThemeCubit, CheckboxThemeState>(
       'should emit default color',
-      build: () => cubit,
+      build: () => checkboxThemeCubit,
       act: (cubit) => cubit.fillDefaultColorChanged(color),
       verify: (cubit) {
         final props = {
@@ -70,7 +77,7 @@ void main() {
 
     blocTest<CheckboxThemeCubit, CheckboxThemeState>(
       'should emit selected color',
-      build: () => cubit,
+      build: () => checkboxThemeCubit,
       act: (cubit) => cubit.fillSelectedColorChanged(color),
       verify: (cubit) {
         final props = {
@@ -84,7 +91,7 @@ void main() {
     );
     blocTest<CheckboxThemeCubit, CheckboxThemeState>(
       'should emit disabled color',
-      build: () => cubit,
+      build: () => checkboxThemeCubit,
       act: (cubit) => cubit.fillDisabledColorChanged(color),
       verify: (cubit) {
         final props = {
@@ -100,7 +107,7 @@ void main() {
 
   blocTest<CheckboxThemeCubit, CheckboxThemeState>(
     'should emit check color',
-    build: () => cubit,
+    build: () => checkboxThemeCubit,
     act: (cubit) => cubit.checkColorChanged(color),
     verify: (cubit) {
       final props = {null: color};
@@ -112,7 +119,7 @@ void main() {
   group('test overlay colors', () {
     blocTest<CheckboxThemeCubit, CheckboxThemeState>(
       'should emit pressed color',
-      build: () => cubit,
+      build: () => checkboxThemeCubit,
       act: (cubit) => cubit.overlayPressedColorChanged(color),
       verify: (cubit) {
         final props = {
@@ -127,7 +134,7 @@ void main() {
 
     blocTest<CheckboxThemeCubit, CheckboxThemeState>(
       'should emit hovered color',
-      build: () => cubit,
+      build: () => checkboxThemeCubit,
       act: (cubit) => cubit.overlayHoveredColorChanged(color),
       verify: (cubit) {
         final props = {
@@ -142,7 +149,7 @@ void main() {
 
     blocTest<CheckboxThemeCubit, CheckboxThemeState>(
       'should emit focused color',
-      build: () => cubit,
+      build: () => checkboxThemeCubit,
       act: (cubit) => cubit.overlayFocusedColorChanged(color),
       verify: (cubit) {
         final props = {
@@ -160,7 +167,7 @@ void main() {
     for (var size in MaterialTapTargetSize.values) {
       blocTest<CheckboxThemeCubit, CheckboxThemeState>(
         'should emit $size',
-        build: () => cubit,
+        build: () => checkboxThemeCubit,
         act: (cubit) {
           cubit.materialTapTargetSize(UtilService.enumToString(size));
         },
@@ -175,7 +182,7 @@ void main() {
 
   blocTest<CheckboxThemeCubit, CheckboxThemeState>(
     'should emit splash radius',
-    build: () => cubit,
+    build: () => checkboxThemeCubit,
     act: (cubit) => cubit.splashRadiusChanged(doubleValue.toString()),
     expect: () => [
       CheckboxThemeState(theme: CheckboxThemeData(splashRadius: doubleValue)),

--- a/test/elevated_button_theme/elevated_button_theme_cubit_test.dart
+++ b/test/elevated_button_theme/elevated_button_theme_cubit_test.dart
@@ -1,24 +1,33 @@
 import 'dart:math';
 
+import 'package:appainter/color_theme/color_theme.dart';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:appainter/elevated_button_theme/elevated_button_theme.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:random_color_scheme/random_color_scheme.dart';
 
+import '../mocks.dart';
 import '../utils.dart';
 
 void main() {
   const defaultElevation = 2.0;
   final colorScheme = ThemeData().colorScheme;
 
-  late ElevatedButtonThemeCubit cubit;
+  late ElevatedButtonThemeCubit elevatedButtonThemeCubit;
+  late ColorThemeCubit colorThemeCubit;
   late ElevatedButtonThemeData theme;
   late Color color;
   late double doubleValue;
 
   setUp(() {
-    cubit = ElevatedButtonThemeCubit();
+    colorThemeCubit = MockColorThemeCubit();
+    when(() => colorThemeCubit.state).thenReturn(ColorThemeState());
+
+    elevatedButtonThemeCubit = ElevatedButtonThemeCubit(
+      colorThemeCubit: colorThemeCubit,
+    );
     color = getRandomColor();
     doubleValue = Random().nextDouble();
   });
@@ -29,14 +38,14 @@ void main() {
       final colorScheme = randomColorSchemeLight(shouldPrint: false);
       theme = ThemeData.from(colorScheme: colorScheme).elevatedButtonTheme;
     },
-    build: () => cubit,
+    build: () => elevatedButtonThemeCubit,
     act: (cubit) => cubit.themeChanged(theme),
     expect: () => [ElevatedButtonThemeState(theme: theme)],
   );
 
   blocTest<ElevatedButtonThemeCubit, ElevatedButtonThemeState>(
     'should emit background default color',
-    build: () => cubit,
+    build: () => elevatedButtonThemeCubit,
     act: (cubit) => cubit.backgroundDefaultColorChanged(color),
     verify: (cubit) {
       final props = {
@@ -53,7 +62,7 @@ void main() {
 
   blocTest<ElevatedButtonThemeCubit, ElevatedButtonThemeState>(
     'should emit background disabled color',
-    build: () => cubit,
+    build: () => elevatedButtonThemeCubit,
     act: (cubit) => cubit.backgroundDisabledColorChanged(color),
     verify: (cubit) {
       final props = {
@@ -70,7 +79,7 @@ void main() {
 
   blocTest<ElevatedButtonThemeCubit, ElevatedButtonThemeState>(
     'should emit foreground default color',
-    build: () => cubit,
+    build: () => elevatedButtonThemeCubit,
     act: (cubit) => cubit.foregroundDefaultColorChanged(color),
     verify: (cubit) {
       final props = {
@@ -87,7 +96,7 @@ void main() {
 
   blocTest<ElevatedButtonThemeCubit, ElevatedButtonThemeState>(
     'should emit foreground disabled color',
-    build: () => cubit,
+    build: () => elevatedButtonThemeCubit,
     act: (cubit) => cubit.foregroundDisabledColorChanged(color),
     verify: (cubit) {
       final props = {
@@ -104,7 +113,7 @@ void main() {
 
   blocTest<ElevatedButtonThemeCubit, ElevatedButtonThemeState>(
     'should emit overlay hovered color',
-    build: () => cubit,
+    build: () => elevatedButtonThemeCubit,
     act: (cubit) => cubit.overlayHoveredColorChanged(color),
     verify: (cubit) {
       final props = {
@@ -122,7 +131,7 @@ void main() {
 
   blocTest<ElevatedButtonThemeCubit, ElevatedButtonThemeState>(
     'should emit overlay focused color',
-    build: () => cubit,
+    build: () => elevatedButtonThemeCubit,
     act: (cubit) => cubit.overlayFocusedColorChanged(color),
     verify: (cubit) {
       final props = {
@@ -140,7 +149,7 @@ void main() {
 
   blocTest<ElevatedButtonThemeCubit, ElevatedButtonThemeState>(
     'should emit elevated button overlay pressed color',
-    build: () => cubit,
+    build: () => elevatedButtonThemeCubit,
     act: (cubit) => cubit.overlayPressedColorChanged(color),
     verify: (cubit) {
       final props = {
@@ -158,7 +167,7 @@ void main() {
 
   blocTest<ElevatedButtonThemeCubit, ElevatedButtonThemeState>(
     'should emit elevated button shadow color',
-    build: () => cubit,
+    build: () => elevatedButtonThemeCubit,
     act: (cubit) => cubit.shadowColorChanged(color),
     verify: (cubit) {
       final props = {null: color};
@@ -172,7 +181,7 @@ void main() {
 
   blocTest<ElevatedButtonThemeCubit, ElevatedButtonThemeState>(
     'should emit default elevation',
-    build: () => cubit,
+    build: () => elevatedButtonThemeCubit,
     act: (cubit) => cubit.defaultElevationChanged(doubleValue.toString()),
     verify: (cubit) {
       final props = {
@@ -192,7 +201,7 @@ void main() {
 
   blocTest<ElevatedButtonThemeCubit, ElevatedButtonThemeState>(
     'should emit elevated button disabled elevation',
-    build: () => cubit,
+    build: () => elevatedButtonThemeCubit,
     act: (cubit) => cubit.disabledElevationChanged(doubleValue.toString()),
     verify: (cubit) {
       final props = {
@@ -212,7 +221,7 @@ void main() {
 
   blocTest<ElevatedButtonThemeCubit, ElevatedButtonThemeState>(
     'should emit hovered elevation',
-    build: () => cubit,
+    build: () => elevatedButtonThemeCubit,
     act: (cubit) => cubit.hoveredElevationChanged(doubleValue.toString()),
     verify: (cubit) {
       final props = {
@@ -232,7 +241,7 @@ void main() {
 
   blocTest<ElevatedButtonThemeCubit, ElevatedButtonThemeState>(
     'should emit focused elevation',
-    build: () => cubit,
+    build: () => elevatedButtonThemeCubit,
     act: (cubit) => cubit.focusedElevationChanged(doubleValue.toString()),
     verify: (cubit) {
       final props = {
@@ -252,7 +261,7 @@ void main() {
 
   blocTest<ElevatedButtonThemeCubit, ElevatedButtonThemeState>(
     'should emit elevated button pressed elevation',
-    build: () => cubit,
+    build: () => elevatedButtonThemeCubit,
     act: (cubit) {
       cubit.pressedElevationChanged(doubleValue.toString());
     },

--- a/test/outlined_button_theme/outlined_button_theme_cubit_test.dart
+++ b/test/outlined_button_theme/outlined_button_theme_cubit_test.dart
@@ -1,23 +1,32 @@
 import 'dart:math';
 
+import 'package:appainter/color_theme/color_theme.dart';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:appainter/outlined_button_theme/outlined_button_theme.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:random_color_scheme/random_color_scheme.dart';
 
+import '../mocks.dart';
 import '../utils.dart';
 
 void main() {
   final colorScheme = ThemeData().colorScheme;
 
-  late OutlinedButtonThemeCubit cubit;
+  late OutlinedButtonThemeCubit outlinedButtonThemeCubit;
+  late ColorThemeCubit colorThemeCubit;
   late OutlinedButtonThemeData theme;
   late Color color;
   late double doubleValue;
 
   setUp(() {
-    cubit = OutlinedButtonThemeCubit();
+    colorThemeCubit = MockColorThemeCubit();
+    when(() => colorThemeCubit.state).thenReturn(ColorThemeState());
+
+    outlinedButtonThemeCubit = OutlinedButtonThemeCubit(
+      colorThemeCubit: colorThemeCubit,
+    );
     color = getRandomColor();
     doubleValue = Random().nextDouble();
   });
@@ -28,14 +37,14 @@ void main() {
       final colorScheme = randomColorSchemeLight(shouldPrint: false);
       theme = ThemeData.from(colorScheme: colorScheme).outlinedButtonTheme;
     },
-    build: () => cubit,
+    build: () => outlinedButtonThemeCubit,
     act: (cubit) => cubit.themeChanged(theme),
     expect: () => [OutlinedButtonThemeState(theme: theme)],
   );
 
   blocTest<OutlinedButtonThemeCubit, OutlinedButtonThemeState>(
     'should emit background color',
-    build: () => cubit,
+    build: () => outlinedButtonThemeCubit,
     act: (cubit) => cubit.backgroundColorChanged(color),
     verify: (cubit) {
       final props = {null: color};
@@ -49,7 +58,7 @@ void main() {
 
   blocTest<OutlinedButtonThemeCubit, OutlinedButtonThemeState>(
     'should emit foreground default color',
-    build: () => cubit,
+    build: () => outlinedButtonThemeCubit,
     act: (cubit) => cubit.foregroundDefaultColorChanged(color),
     verify: (cubit) {
       final props = {
@@ -66,7 +75,7 @@ void main() {
 
   blocTest<OutlinedButtonThemeCubit, OutlinedButtonThemeState>(
     'should emit foreground disabled color',
-    build: () => cubit,
+    build: () => outlinedButtonThemeCubit,
     act: (cubit) => cubit.foregroundDisabledColorChanged(color),
     verify: (cubit) {
       final props = {
@@ -83,7 +92,7 @@ void main() {
 
   blocTest<OutlinedButtonThemeCubit, OutlinedButtonThemeState>(
     'should emit overlay hovered color',
-    build: () => cubit,
+    build: () => outlinedButtonThemeCubit,
     act: (cubit) => cubit.overlayHoveredColorChanged(color),
     verify: (cubit) {
       final props = {
@@ -101,7 +110,7 @@ void main() {
 
   blocTest<OutlinedButtonThemeCubit, OutlinedButtonThemeState>(
     'should emit overlay focused color',
-    build: () => cubit,
+    build: () => outlinedButtonThemeCubit,
     act: (cubit) => cubit.overlayFocusedColorChanged(color),
     verify: (cubit) {
       final props = {
@@ -119,7 +128,7 @@ void main() {
 
   blocTest<OutlinedButtonThemeCubit, OutlinedButtonThemeState>(
     'should emit overlay pressed color',
-    build: () => cubit,
+    build: () => outlinedButtonThemeCubit,
     act: (cubit) => cubit.overlayPressedColorChanged(color),
     verify: (cubit) {
       final props = {
@@ -137,7 +146,7 @@ void main() {
 
   blocTest<OutlinedButtonThemeCubit, OutlinedButtonThemeState>(
     'should emit shadow color',
-    build: () => cubit,
+    build: () => outlinedButtonThemeCubit,
     act: (cubit) => cubit.shadowColorChanged(color),
     verify: (cubit) {
       final props = {null: color};
@@ -147,7 +156,7 @@ void main() {
 
   blocTest<OutlinedButtonThemeCubit, OutlinedButtonThemeState>(
     'should emit elevation',
-    build: () => cubit,
+    build: () => outlinedButtonThemeCubit,
     act: (cubit) => cubit.elevationChanged(doubleValue.toString()),
     verify: (cubit) {
       final props = {null: doubleValue};

--- a/test/radio_theme/radio_theme_cubit_test.dart
+++ b/test/radio_theme/radio_theme_cubit_test.dart
@@ -1,16 +1,20 @@
 import 'dart:math';
 
+import 'package:appainter/color_theme/color_theme.dart';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:appainter/radio_theme/radio_theme.dart';
 import 'package:appainter/services/services.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:random_color_scheme/random_color_scheme.dart';
 
+import '../mocks.dart';
 import '../utils.dart';
 
 void main() {
-  late RadioThemeCubit cubit;
+  late RadioThemeCubit radioThemeCubit;
+  late ColorThemeCubit colorThemeCubit;
   late RadioThemeData theme;
   late Color color;
   late double doubleValue;
@@ -36,7 +40,10 @@ void main() {
   });
 
   setUp(() {
-    cubit = RadioThemeCubit();
+    colorThemeCubit = MockColorThemeCubit();
+    when(() => colorThemeCubit.state).thenReturn(ColorThemeState());
+
+    radioThemeCubit = RadioThemeCubit(colorThemeCubit: colorThemeCubit);
     color = getRandomColor();
     doubleValue = Random().nextDouble();
   });
@@ -47,7 +54,7 @@ void main() {
       final colorScheme = randomColorSchemeLight(shouldPrint: false);
       theme = ThemeData.from(colorScheme: colorScheme).radioTheme;
     },
-    build: () => cubit,
+    build: () => radioThemeCubit,
     act: (cubit) => cubit.themeChanged(theme),
     expect: () => [RadioThemeState(theme: theme)],
   );
@@ -55,7 +62,7 @@ void main() {
   group('test fill colors', () {
     blocTest<RadioThemeCubit, RadioThemeState>(
       'should emit default color',
-      build: () => cubit,
+      build: () => radioThemeCubit,
       act: (cubit) => cubit.fillDefaultColorChanged(color),
       verify: (cubit) {
         final props = {
@@ -70,7 +77,7 @@ void main() {
 
     blocTest<RadioThemeCubit, RadioThemeState>(
       'should emit selected color',
-      build: () => cubit,
+      build: () => radioThemeCubit,
       act: (cubit) => cubit.fillSelectedColorChanged(color),
       verify: (cubit) {
         final props = {
@@ -84,7 +91,7 @@ void main() {
     );
     blocTest<RadioThemeCubit, RadioThemeState>(
       'should emit disabled color',
-      build: () => cubit,
+      build: () => radioThemeCubit,
       act: (cubit) => cubit.fillDisabledColorChanged(color),
       verify: (cubit) {
         final props = {
@@ -101,7 +108,7 @@ void main() {
   group('test overlay colors', () {
     blocTest<RadioThemeCubit, RadioThemeState>(
       'should emit pressed color',
-      build: () => cubit,
+      build: () => radioThemeCubit,
       act: (cubit) => cubit.overlayPressedColorChanged(color),
       verify: (cubit) {
         final props = {
@@ -116,7 +123,7 @@ void main() {
 
     blocTest<RadioThemeCubit, RadioThemeState>(
       'should emit hovered color',
-      build: () => cubit,
+      build: () => radioThemeCubit,
       act: (cubit) => cubit.overlayHoveredColorChanged(color),
       verify: (cubit) {
         final props = {
@@ -131,7 +138,7 @@ void main() {
 
     blocTest<RadioThemeCubit, RadioThemeState>(
       'should emit focused color',
-      build: () => cubit,
+      build: () => radioThemeCubit,
       act: (cubit) => cubit.overlayFocusedColorChanged(color),
       verify: (cubit) {
         final props = {
@@ -149,7 +156,7 @@ void main() {
     for (var size in MaterialTapTargetSize.values) {
       blocTest<RadioThemeCubit, RadioThemeState>(
         'should emit $size',
-        build: () => cubit,
+        build: () => radioThemeCubit,
         act: (cubit) {
           cubit.materialTapTargetSize(UtilService.enumToString(size));
         },
@@ -162,7 +169,7 @@ void main() {
 
   blocTest<RadioThemeCubit, RadioThemeState>(
     'should emit splash radius',
-    build: () => cubit,
+    build: () => radioThemeCubit,
     act: (cubit) => cubit.splashRadiusChanged(doubleValue.toString()),
     expect: () => [
       RadioThemeState(theme: RadioThemeData(splashRadius: doubleValue)),

--- a/test/switch_theme/switch_theme_cubit_test.dart
+++ b/test/switch_theme/switch_theme_cubit_test.dart
@@ -1,16 +1,20 @@
 import 'dart:math';
 
+import 'package:appainter/color_theme/color_theme.dart';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:appainter/services/services.dart';
 import 'package:appainter/switch_theme/switch_theme.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:random_color_scheme/random_color_scheme.dart';
 
+import '../mocks.dart';
 import '../utils.dart';
 
 void main() {
-  late SwitchThemeCubit cubit;
+  late SwitchThemeCubit switchThemeCubit;
+  late ColorThemeCubit colorThemeCubit;
   late SwitchThemeData theme;
   late Color color;
   late double doubleValue;
@@ -44,7 +48,10 @@ void main() {
   });
 
   setUp(() {
-    cubit = SwitchThemeCubit();
+    colorThemeCubit = MockColorThemeCubit();
+    when(() => colorThemeCubit.state).thenReturn(ColorThemeState());
+
+    switchThemeCubit = SwitchThemeCubit(colorThemeCubit: colorThemeCubit);
     color = getRandomColor();
     doubleValue = Random().nextDouble();
   });
@@ -55,7 +62,7 @@ void main() {
       final colorScheme = randomColorSchemeLight(shouldPrint: false);
       theme = ThemeData.from(colorScheme: colorScheme).switchTheme;
     },
-    build: () => cubit,
+    build: () => switchThemeCubit,
     act: (cubit) => cubit.themeChanged(theme),
     expect: () => [SwitchThemeState(theme: theme)],
   );
@@ -63,7 +70,7 @@ void main() {
   group('test thumb colors', () {
     blocTest<SwitchThemeCubit, SwitchThemeState>(
       'should emit default color',
-      build: () => cubit,
+      build: () => switchThemeCubit,
       act: (cubit) => cubit.thumbDefaultColorChanged(color),
       verify: (cubit) {
         final props = {
@@ -78,7 +85,7 @@ void main() {
 
     blocTest<SwitchThemeCubit, SwitchThemeState>(
       'should emit selected color',
-      build: () => cubit,
+      build: () => switchThemeCubit,
       act: (cubit) => cubit.thumbSelectedColorChanged(color),
       verify: (cubit) {
         final props = {
@@ -93,7 +100,7 @@ void main() {
 
     blocTest<SwitchThemeCubit, SwitchThemeState>(
       'should emit disabled color',
-      build: () => cubit,
+      build: () => switchThemeCubit,
       act: (cubit) => cubit.thumbDisabledColorChanged(color),
       verify: (cubit) {
         final props = {
@@ -110,7 +117,7 @@ void main() {
   group('test track colors', () {
     blocTest<SwitchThemeCubit, SwitchThemeState>(
       'should emit default color',
-      build: () => cubit,
+      build: () => switchThemeCubit,
       act: (cubit) => cubit.trackDefaultColorChanged(color),
       verify: (cubit) {
         final props = {
@@ -125,7 +132,7 @@ void main() {
 
     blocTest<SwitchThemeCubit, SwitchThemeState>(
       'should emit selected color',
-      build: () => cubit,
+      build: () => switchThemeCubit,
       act: (cubit) => cubit.trackSelectedColorChanged(color),
       verify: (cubit) {
         final props = {
@@ -143,7 +150,7 @@ void main() {
 
     blocTest<SwitchThemeCubit, SwitchThemeState>(
       'should emit disabled color',
-      build: () => cubit,
+      build: () => switchThemeCubit,
       act: (cubit) => cubit.trackDisabledColorChanged(color),
       verify: (cubit) {
         final props = {
@@ -164,7 +171,7 @@ void main() {
     for (var size in MaterialTapTargetSize.values) {
       blocTest<SwitchThemeCubit, SwitchThemeState>(
         'should emit $size',
-        build: () => cubit,
+        build: () => switchThemeCubit,
         act: (cubit) {
           cubit.materialTapTargetSize(UtilService.enumToString(size));
         },
@@ -178,7 +185,7 @@ void main() {
   group('test overlay colors', () {
     blocTest<SwitchThemeCubit, SwitchThemeState>(
       'should emit pressed color',
-      build: () => cubit,
+      build: () => switchThemeCubit,
       act: (cubit) => cubit.overlayPressedColorChanged(color),
       verify: (cubit) {
         final props = {
@@ -193,7 +200,7 @@ void main() {
 
     blocTest<SwitchThemeCubit, SwitchThemeState>(
       'should emit hovered color',
-      build: () => cubit,
+      build: () => switchThemeCubit,
       act: (cubit) => cubit.overlayHoveredColorChanged(color),
       verify: (cubit) {
         final props = {
@@ -208,7 +215,7 @@ void main() {
 
     blocTest<SwitchThemeCubit, SwitchThemeState>(
       'should emit focused color',
-      build: () => cubit,
+      build: () => switchThemeCubit,
       act: (cubit) => cubit.overlayFocusedColorChanged(color),
       verify: (cubit) {
         final props = {
@@ -224,7 +231,7 @@ void main() {
 
   blocTest<SwitchThemeCubit, SwitchThemeState>(
     'should emit splash radius',
-    build: () => cubit,
+    build: () => switchThemeCubit,
     act: (cubit) => cubit.splashRadiusChanged(doubleValue.toString()),
     expect: () => [
       SwitchThemeState(theme: SwitchThemeData(splashRadius: doubleValue)),

--- a/test/text_button_theme/text_button_theme_cubit_test.dart
+++ b/test/text_button_theme/text_button_theme_cubit_test.dart
@@ -1,23 +1,32 @@
 import 'dart:math';
 
+import 'package:appainter/color_theme/color_theme.dart';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:appainter/text_button_theme/text_button_theme.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:random_color_scheme/random_color_scheme.dart';
 
+import '../mocks.dart';
 import '../utils.dart';
 
 void main() {
   final colorScheme = ThemeData().colorScheme;
 
-  late TextButtonThemeCubit cubit;
+  late TextButtonThemeCubit textButtonThemeCubit;
+  late ColorThemeCubit colorThemeCubit;
   late TextButtonThemeData theme;
   late Color color;
   late double doubleValue;
 
   setUp(() {
-    cubit = TextButtonThemeCubit();
+    colorThemeCubit = MockColorThemeCubit();
+    when(() => colorThemeCubit.state).thenReturn(ColorThemeState());
+
+    textButtonThemeCubit = TextButtonThemeCubit(
+      colorThemeCubit: colorThemeCubit,
+    );
     color = getRandomColor();
     doubleValue = Random().nextDouble();
   });
@@ -28,14 +37,14 @@ void main() {
       final colorScheme = randomColorSchemeLight(shouldPrint: false);
       theme = ThemeData.from(colorScheme: colorScheme).textButtonTheme;
     },
-    build: () => cubit,
+    build: () => textButtonThemeCubit,
     act: (cubit) => cubit.themeChanged(theme),
     expect: () => [TextButtonThemeState(theme: theme)],
   );
 
   blocTest<TextButtonThemeCubit, TextButtonThemeState>(
     'should emit background color',
-    build: () => cubit,
+    build: () => textButtonThemeCubit,
     act: (cubit) => cubit.backgroundColorChanged(color),
     verify: (cubit) {
       final props = {null: color};
@@ -50,7 +59,7 @@ void main() {
   group('test foreground colors', () {
     blocTest<TextButtonThemeCubit, TextButtonThemeState>(
       'should emit default color',
-      build: () => cubit,
+      build: () => textButtonThemeCubit,
       act: (cubit) => cubit.foregroundDefaultColorChanged(color),
       verify: (cubit) {
         final props = {
@@ -67,7 +76,7 @@ void main() {
 
     blocTest<TextButtonThemeCubit, TextButtonThemeState>(
       'should emit disabled color',
-      build: () => cubit,
+      build: () => textButtonThemeCubit,
       act: (cubit) => cubit.foregroundDisabledColorChanged(color),
       verify: (cubit) {
         final props = {
@@ -86,7 +95,7 @@ void main() {
   group('test overlay colors', () {
     blocTest<TextButtonThemeCubit, TextButtonThemeState>(
       'should emit hovered color',
-      build: () => cubit,
+      build: () => textButtonThemeCubit,
       act: (cubit) => cubit.overlayHoveredColorChanged(color),
       verify: (cubit) {
         final props = {
@@ -104,7 +113,7 @@ void main() {
 
     blocTest<TextButtonThemeCubit, TextButtonThemeState>(
       'should emit focused color',
-      build: () => cubit,
+      build: () => textButtonThemeCubit,
       act: (cubit) => cubit.overlayFocusedColorChanged(color),
       verify: (cubit) {
         final props = {
@@ -122,7 +131,7 @@ void main() {
 
     blocTest<TextButtonThemeCubit, TextButtonThemeState>(
       'should emit pressed color',
-      build: () => cubit,
+      build: () => textButtonThemeCubit,
       act: (cubit) => cubit.overlayPressedColorChanged(color),
       verify: (cubit) {
         final props = {
@@ -141,7 +150,7 @@ void main() {
 
   blocTest<TextButtonThemeCubit, TextButtonThemeState>(
     'should emit shadow color',
-    build: () => cubit,
+    build: () => textButtonThemeCubit,
     act: (cubit) => cubit.shadowColorChanged(color),
     verify: (cubit) {
       final props = {null: color};
@@ -151,7 +160,7 @@ void main() {
 
   blocTest<TextButtonThemeCubit, TextButtonThemeState>(
     'should emit elevation',
-    build: () => cubit,
+    build: () => textButtonThemeCubit,
     act: (cubit) => cubit.elevationChanged(doubleValue.toString()),
     verify: (cubit) {
       final props = {null: doubleValue};


### PR DESCRIPTION
- Some of the cubits use the default `ThemeData` to get the default colors
  - These cubits' default colors will become out-of-sync if the colors are changed in `ColorThemeState`
- Fix the cubits to use the colors in `ColorThemeState` to get the default colors