### PR TITLE
fix: default advanced dark theme

### DIFF
--- a/lib/advanced_theme/cubit/advanced_theme_cubit.dart
+++ b/lib/advanced_theme/cubit/advanced_theme_cubit.dart
@@ -57,12 +57,6 @@ class AdvancedThemeCubit extends Cubit<AdvancedThemeState> {
     required this.textThemeCubit,
   }) : super(const AdvancedThemeState());
 
-  static const _colorSchemeDark = ColorScheme.dark(
-    primary: Colors.blue,
-    secondary: Colors.blue,
-    surface: Colors.blue,
-  );
-
   void themeBrightnessChanged(bool isDark) {
     colorThemeCubit.themeChanged(_getDefaultTheme(isDark: isDark));
     textThemeCubit.themeBrightnessChanged(isDark);
@@ -111,8 +105,6 @@ class AdvancedThemeCubit extends Cubit<AdvancedThemeState> {
   }
 
   ThemeData _getDefaultTheme({bool? isDark}) {
-    return isDark ?? state.isDark
-        ? ThemeData.from(colorScheme: _colorSchemeDark)
-        : ThemeData();
+    return isDark ?? state.isDark ? ThemeData.dark() : ThemeData.light();
   }
 }

--- a/test/advanced_theme/advanced_theme_cubit_test.dart
+++ b/test/advanced_theme/advanced_theme_cubit_test.dart
@@ -195,12 +195,5 @@ void main() {
 }
 
 ThemeData _getDefaultTheme({required bool isDark}) {
-  return isDark
-      ? ThemeData.from(
-          colorScheme: const ColorScheme.dark(
-          primary: Colors.blue,
-          secondary: Colors.blue,
-          surface: Colors.blue,
-        ))
-      : ThemeData();
+  return isDark ? ThemeData.dark() : ThemeData.light();
 }


### PR DESCRIPTION
Fix to use `ThemeData.dark` as the default dark them in advanced mode