### PR TITLE
feat: add internal packages for generating theme docs

### DIFF
--- a/.github/workflows/appainter_annotations.yml
+++ b/.github/workflows/appainter_annotations.yml
@@ -1,0 +1,37 @@
+name: Appainter Annotations
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+defaults:
+  run:
+    working-directory: packages/annotations
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+
+      - name: Setup Dart 💻
+        uses: dart-lang/setup-dart@v1.3
+
+      - name: Cache Pub 💾
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.PUB_CACHE }}
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+
+      - name: Run linting 🧪
+        run: |
+          dart pub get
+          dart format --output=none --set-exit-if-changed .
+          dart analyze

--- a/.github/workflows/appainter_builder.yml
+++ b/.github/workflows/appainter_builder.yml
@@ -1,0 +1,59 @@
+name: Appainter Builder
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+defaults:
+  run:
+    working-directory: packages/builder
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+
+      - name: Setup Dart 💻
+        uses: dart-lang/setup-dart@v1.3
+
+      - name: Cache Pub 💾
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.PUB_CACHE }}
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+
+      - name: Run tests 🧪
+        run: |
+          dart pub get
+          dart test --coverage=./coverage
+          dart run coverage:format_coverage --packages=.packages --report-on=lib --lcov -o ./coverage/lcov.info -i ./coverage/
+
+      - name: Upload coverage report 📡
+        uses: codecov/codecov-action@v3.0.0
+        with:
+          files: packages/builder/coverage/lcov.info
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+
+      - name: Setup Dart 💻
+        uses: dart-lang/setup-dart@v1.3
+
+      - name: Run linting 🧪
+        run: |
+          dart pub get
+          dart format --output=none --set-exit-if-changed .
+          dart analyze

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,28 +1,6 @@
-# This file configures the analyzer, which statically analyzes Dart code to
-# check for errors, warnings, and lints.
-#
-# The issues identified by the analyzer are surfaced in the UI of Dart-enabled
-# IDEs (https://dart.dev/tools#ides-and-editors). The analyzer can also be
-# invoked from the command line by running `flutter analyze`.
-
-# The following line activates a set of recommended lints for Flutter apps,
-# packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
 
-linter:
-  # The lint rules applied to this project can be customized in the
-  # section below to disable rules from the `package:flutter_lints/flutter.yaml`
-  # included above or to enable additional rules. A list of all available lints
-  # and their documentation is published at
-  # https://dart-lang.github.io/linter/lints/index.html.
-  #
-  # Instead of disabling a lint rule for the entire project in the
-  # section below, it can also be suppressed for a single line of code
-  # or a specific dart file by using the `// ignore: name_of_lint` and
-  # `// ignore_for_file: name_of_lint` syntax on the line or in the file
-  # producing the lint.
-  rules:
-    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
-    # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
-# Additional information about this file can be found at
-# https://dart.dev/guides/language/analysis-options
+analyzer:
+  exclude:
+    - example/
+    - packages/

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:flutter_lints/flutter.yaml

--- a/packages/.gitignore
+++ b/packages/.gitignore
@@ -1,0 +1,1 @@
+pubspec.lock

--- a/packages/annotations/analysis_options.yaml
+++ b/packages/annotations/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:flutter_lints/flutter.yaml

--- a/packages/annotations/lib/annotations.dart
+++ b/packages/annotations/lib/annotations.dart
@@ -1,0 +1,3 @@
+library appainter_annotations;
+
+export 'src/theme_docs.dart';

--- a/packages/annotations/lib/src/theme_docs.dart
+++ b/packages/annotations/lib/src/theme_docs.dart
@@ -1,0 +1,3 @@
+class ThemeDocs {
+  const ThemeDocs();
+}

--- a/packages/annotations/pubspec.yaml
+++ b/packages/annotations/pubspec.yaml
@@ -1,0 +1,10 @@
+name: appainter_annotations
+description: Annotations for generating theme documentations
+version: 1.0.0
+publish_to: none
+
+environment:
+  sdk: ">=2.12.0 <3.0.0"
+
+dev_dependencies:
+  flutter_lints: ^1.0.0

--- a/packages/builder/analysis_options.yaml
+++ b/packages/builder/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:flutter_lints/flutter.yaml

--- a/packages/builder/build.yaml
+++ b/packages/builder/build.yaml
@@ -1,0 +1,19 @@
+targets:
+  $default:
+    builders:
+      appainter_builder:
+        enabled: true
+        generate_for:
+          exclude:
+            - test
+            - example
+
+builders:
+  appainter_builder:
+    target: ":appainter_builder"
+    import: "package:appainter_builder/builder.dart"
+    builder_factories: ["generateThemeDocs"]
+    build_extensions: { ".dart": [".g.dart"] }
+    auto_apply: dependents
+    build_to: cache
+    applies_builders: ["source_gen|combining_builder"]

--- a/packages/builder/lib/builder.dart
+++ b/packages/builder/lib/builder.dart
@@ -1,0 +1,9 @@
+library appainter_builder;
+
+import 'package:build/build.dart';
+import 'package:appainter_builder/src/theme_docs_generator.dart';
+import 'package:source_gen/source_gen.dart';
+
+Builder generateThemeDocs(BuilderOptions _) {
+  return SharedPartBuilder([const ThemeDocsGenerator()], 'themeDocsGenerator');
+}

--- a/packages/builder/lib/src/http_client.dart
+++ b/packages/builder/lib/src/http_client.dart
@@ -1,0 +1,10 @@
+import 'package:http/http.dart' as http;
+
+class HttpClient {
+  const HttpClient();
+
+  Future<http.Response> get(String url) async {
+    final parsedUrl = Uri.parse(url);
+    return http.get(parsedUrl);
+  }
+}

--- a/packages/builder/lib/src/theme_docs_generator.dart
+++ b/packages/builder/lib/src/theme_docs_generator.dart
@@ -1,0 +1,87 @@
+import 'package:analyzer/dart/element/element.dart';
+import 'package:appainter_annotations/annotations.dart';
+import 'package:appainter_builder/src/http_client.dart';
+import 'package:build/build.dart';
+import 'package:collection/collection.dart';
+import 'package:html/parser.dart' show parse;
+import 'package:source_gen/source_gen.dart';
+
+class ThemeDocsGenerator extends GeneratorForAnnotation<ThemeDocs> {
+  final HttpClient client;
+
+  const ThemeDocsGenerator({this.client = const HttpClient()}) : super();
+
+  static const _allowedPropertyTypes = {'color', 'double'};
+
+  @override
+  Future<String> generateForAnnotatedElement(
+    Element element,
+    ConstantReader annotation,
+    BuildStep buildStep,
+  ) async {
+    if (element is! ClassElement) {
+      throw InvalidGenerationSourceError(
+        'Only classes can be annotated with "ThemeDocumentation". "$element" is'
+        'not a ClassElement.',
+        element: element,
+      );
+    }
+
+    final className = element.name.replaceFirst(RegExp(r'Cubit$'), '');
+    late final Map<String, String> props;
+    if (className == 'ColorTheme') {
+      props = await _getThemeProperties('ThemeData');
+    } else {
+      props = await _getThemeProperties(className);
+    }
+
+    final buffer = StringBuffer('class ${className}Docs {');
+    for (var prop in props.entries) {
+      buffer.writeln("static const ${prop.key} = '${prop.value}';");
+    }
+    buffer.writeln('}');
+
+    return buffer.toString();
+  }
+
+  Future<Map<String, String>> _getThemeProperties(
+    String className, {
+    Set<String> allowedPropertyTypes = _allowedPropertyTypes,
+  }) async {
+    final res = await client.get(
+      'https://api.flutter.dev/flutter/material/$className-class.html',
+    );
+    final document = parse(res.body);
+
+    final propsElem = document.querySelector('dl.properties')!;
+    final propElems = propsElem.getElementsByTagName('dt');
+    final propDescElems = propsElem.getElementsByTagName('dd');
+
+    final propsMap = <String, String>{};
+    for (var elems in IterableZip([propElems, propDescElems])) {
+      final propElem = elems[0];
+      final propDescElem = elems[1];
+
+      if (propElem.querySelector('a.deprecated') != null) {
+        continue;
+      }
+
+      final signatureElem = propElem.querySelector('span.signature')!;
+      final propType = signatureElem.querySelector('a')!.text.toLowerCase();
+      if (!allowedPropertyTypes.contains(propType)) {
+        continue;
+      }
+
+      final propName = propElem.querySelector('span.name')!.text;
+      propDescElem.querySelector('div')!.remove();
+      final propDesc = propDescElem.text
+          .replaceFirst('[...]', '')
+          .trim()
+          .replaceAll(RegExp(r'^\s+', multiLine: true), '')
+          .replaceAll('\n', ' ');
+      propsMap[propName] = propDesc;
+    }
+
+    return propsMap;
+  }
+}

--- a/packages/builder/pubspec.yaml
+++ b/packages/builder/pubspec.yaml
@@ -1,0 +1,22 @@
+name: appainter_builder
+description: Builder for generating theme documentations
+version: 1.0.0
+publish_to: none
+
+environment:
+  sdk: ">=2.12.0 <3.0.0"
+
+dependencies:
+  appainter_annotations:
+    path: ../annotations/
+  build: ^2.2.1
+  html: ^0.15.0
+  http: ^0.13.4
+  source_gen: ^1.2.1
+
+dev_dependencies:
+  build_runner: ^2.1.8
+  build_test: ^2.1.5
+  flutter_lints: ^1.0.4
+  mocktail: ^0.3.0
+  test: ^1.20.2

--- a/packages/builder/pubspec.yaml
+++ b/packages/builder/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.1.8
   build_test: ^2.1.5
+  coverage: ^1.2.0
   flutter_lints: ^1.0.4
   mocktail: ^0.3.0
   test: ^1.20.2

--- a/packages/builder/test/http_client_test.dart
+++ b/packages/builder/test/http_client_test.dart
@@ -1,0 +1,13 @@
+import 'package:appainter_builder/src/http_client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late HttpClient client;
+
+  setUp(() => client = const HttpClient());
+
+  test('gets request', () async {
+    final res = await client.get('https://pub.dev/');
+    expect(res.statusCode, equals(200));
+  });
+}

--- a/packages/builder/test/mocks.dart
+++ b/packages/builder/test/mocks.dart
@@ -1,0 +1,108 @@
+const mockPropertiesHtml = r'''
+<dl class="properties">
+  <dt id="accentColor" class="property">
+    <span class="name"><a class="deprecated" href="material/ThemeData/accentColor.html">accentColor</a></span>
+    <span class="signature">→ <a href="dart-ui/Color-class.html">Color</a></span>
+  </dt>
+  <dd>
+    Obsolete property that was originally used as the foreground color for
+    widgets (knobs, text, overscroll edge effect, etc).
+    <a href="material/ThemeData/accentColor.html">[...]</a>
+    <div class="features">
+      @<a href="dart-core/Deprecated-class.html">Deprecated</a>('Use
+      colorScheme.secondary instead. ' 'For more information, consult the
+      migration guide at '
+      'https://flutter.dev/docs/release/breaking-changes/theme-data-accent-properties#migration-guide.
+      ' 'This feature was deprecated after v2.3.0-0.1.pre.'), final
+    </div>
+  </dd>
+
+  <dt id="appBarTheme" class="property">
+    <span class="name"><a href="material/ThemeData/appBarTheme.html">appBarTheme</a></span>
+    <span class="signature">→ <a href="material/AppBarTheme-class.html">AppBarTheme</a></span>
+  </dt>
+  <dd>
+    A theme for customizing the color, elevation, brightness, iconTheme and
+    textTheme of <a href="material/AppBar-class.html">AppBar</a>s.
+    <div class="features">final</div>
+  </dd>
+
+  <dt id="primaryColor" class="property">
+    <span class="name"><a href="material/ThemeData/primaryColor.html">primaryColor</a></span>
+    <span class="signature">→ <a href="dart-ui/Color-class.html">Color</a></span>
+  </dt>
+  <dd>
+    The background color for major parts of the app (toolbars, tab bars, etc)
+    <a href="material/ThemeData/primaryColor.html">[...]</a>
+    <div class="features">final</div>
+  </dd>
+
+  <dt id="primaryColorDark" class="property">
+    <span class="name"><a href="material/ThemeData/primaryColorDark.html">primaryColorDark</a></span>
+    <span class="signature">→ <a href="dart-ui/Color-class.html">Color</a></span>
+  </dt>
+  <dd>
+    A darker version of the
+    <a href="material/ThemeData/primaryColor.html">primaryColor</a>.
+    <div class="features">final</div>
+  </dd>
+
+  <dt id="primaryColorLight" class="property">
+    <span class="name"><a href="material/ThemeData/primaryColorLight.html">primaryColorLight</a></span>
+    <span class="signature">→ <a href="dart-ui/Color-class.html">Color</a></span>
+  </dt>
+  <dd>
+    A lighter version of the
+    <a href="material/ThemeData/primaryColor.html">primaryColor</a>.
+    <div class="features">final</div>
+  </dd>
+</dl>
+''';
+
+const mockInput = r'''
+library builder_test;
+import 'package:appainter_annotations/annotations.dart';
+
+part 'test.g.dart';
+
+@ThemeDocs()
+class Test {}
+''';
+
+const mockColorThemeInput = r'''
+library builder_test;
+import 'package:appainter_annotations/annotations.dart';
+
+part 'test.g.dart';
+
+@ThemeDocs()
+class ColorTheme {}
+''';
+
+const mockAnnotations = r'''
+library appainter_annotations;
+export 'src/theme_docs.dart';
+''';
+
+const mockThemeDocs = r'''
+class ThemeDocs {
+  const ThemeDocs();
+}
+''';
+
+const expectedOutput = r'''
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of builder_test;
+
+// **************************************************************************
+// ThemeDocsGenerator
+// **************************************************************************
+
+class TestDocs {
+  static const primaryColor =
+      'The background color for major parts of the app (toolbars, tab bars, etc)';
+  static const primaryColorDark = 'A darker version of the primaryColor.';
+  static const primaryColorLight = 'A lighter version of the primaryColor.';
+}
+''';

--- a/packages/builder/test/theme_docs_generator_test.dart
+++ b/packages/builder/test/theme_docs_generator_test.dart
@@ -1,0 +1,61 @@
+import 'package:appainter_builder/src/http_client.dart';
+import 'package:appainter_builder/src/theme_docs_generator.dart';
+import 'package:http/http.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:source_gen/source_gen.dart';
+import 'package:test/test.dart';
+import 'package:build_test/build_test.dart';
+
+import 'mocks.dart';
+
+class MockHttpClient extends Mock implements HttpClient {}
+
+class MockResponse extends Mock implements Response {}
+
+void main() {
+  late PartBuilder builder;
+  late HttpClient client;
+  late Map<String, String> assets;
+
+  setUp(() {
+    client = MockHttpClient();
+    final generator = ThemeDocsGenerator(client: client);
+    builder = PartBuilder([generator], '.g.dart');
+
+    assets = {
+      'appainter_annotations|lib/annotations.dart': mockAnnotations,
+      'appainter_annotations|lib/src/theme_docs.dart': mockThemeDocs,
+    };
+
+    final Response response = MockResponse();
+    when((() => response.body)).thenReturn(mockPropertiesHtml);
+    when(() => client.get(any())).thenAnswer(
+      (invocation) => Future.value(response),
+    );
+  });
+
+  test('generates theme docs', () async {
+    assets.addAll({'builder_test|lib/test.dart': mockInput});
+    final outputs = {'builder_test|lib/test.g.dart': expectedOutput};
+    await testBuilder(
+      builder,
+      assets,
+      outputs: outputs,
+      rootPackage: 'builder_test',
+    );
+  });
+
+  test('calls to theme data docs for color theme', () async {
+    assets.addAll({'builder_test|lib/test.dart': mockColorThemeInput});
+    await testBuilder(
+      builder,
+      assets,
+      rootPackage: 'builder_test',
+    );
+    verify(
+      () => client.get(
+        'https://api.flutter.dev/flutter/material/ThemeData-class.html',
+      ),
+    ).called(1);
+  });
+}


### PR DESCRIPTION
Add internal packages to generate a class like below containing the docs for themes:
- `appainter_annotations` - provide the annotation to apply onto the class for the docs generation
- `appainter_builder` - generator for the theme docs

```dart
class AppBarThemeDocs {
  static const backgroundColor =
      'Overrides the default value of AppBar.backgroundColor in all descendant AppBar widgets.';
  static const elevation =
      'Overrides the default value of AppBar.elevation in all descendant AppBar widgets.';
  static const foregroundColor =
      'Overrides the default value of AppBar.foregroundColor in all descendant widgets.';
  static const shadowColor =
      'Overrides the default value for AppBar.shadowColor in all descendant widgets.';
  static const titleSpacing =
      'Overrides the default value for the obsolete AppBar.titleSpacing property in all descendant AppBar widgets.';
  static const toolbarHeight =
      'Overrides the default value for the AppBar.toolbarHeight property in all descendant AppBar widgets.';
}
```

Relates to #287 