### PR TITLE
feat(packages): update to allow user defined property types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,12 +209,12 @@ Temporary Items
 .apdisk
 
 ### VisualStudioCode ###
-.vscode/*
-.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
-*.code-workspace
+**/.vscode/*
+**/.vscode/settings.json
+!**/.vscode/tasks.json
+!**/.vscode/launch.json
+!**/.vscode/extensions.json
+**/*.code-workspace
 
 ### VisualStudioCode Patch ###
 # Ignore all local history of files

--- a/packages/annotations/lib/src/theme_docs.dart
+++ b/packages/annotations/lib/src/theme_docs.dart
@@ -1,3 +1,7 @@
 class ThemeDocs {
-  const ThemeDocs();
+  final Set<String> propertyTypes;
+
+  const ThemeDocs({this.propertyTypes = defaultPropertyTyles});
+
+  static const defaultPropertyTyles = {'color', 'double', 'bool'};
 }

--- a/packages/builder/test/mocks.dart
+++ b/packages/builder/test/mocks.dart
@@ -138,7 +138,11 @@ export 'src/theme_docs.dart';
 
 const mockThemeDocs = r'''
 class ThemeDocs {
-  const ThemeDocs();
+  final Set<String> propertyTypes;
+
+  const ThemeDocs({this.propertyTypes = defaultPropertyTyles});
+
+  static const defaultPropertyTyles = {'color', 'double', 'bool'};
 }
 ''';
 
@@ -155,6 +159,9 @@ class TestDocs {
   static const backgroundColor =
       """Overrides the default value of AppBar.backgroundColor in all
 descendant AppBar widgets.""";
+  static const centerTitle =
+      """Overrides the default value for AppBar.centerTitle. property in all
+descendant widgets.""";
   static const elevation =
       """Overrides the default value of AppBar.elevation in all descendant
 AppBar widgets.""";

--- a/packages/builder/test/theme_docs_generator_test.dart
+++ b/packages/builder/test/theme_docs_generator_test.dart
@@ -46,7 +46,7 @@ void main() {
 
     // Should make 1 GET call to fetch the main theme docs page, then 3 more
     // GET calls to fetch the descriptions of the 3 properties
-    verify(() => client.get(any())).called(4);
+    verify(() => client.get(any())).called(5);
   });
 
   test('calls to theme data docs for color theme', () async {


### PR DESCRIPTION
Add to allow user to define the property types to retrieve from API docs, e.g.

```dart
@ThemeDocs(propertyTypes: {'color', 'int'})
class SomeClass {}
```