### PR TITLE
ci(github-actions): reenable integration tests on web

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -80,7 +80,7 @@ jobs:
             os: ubuntu-latest
 
           - type: web
-            os: macos-latest
+            os: ubuntu-latest
 
     steps:
       - name: Checkout 🛎️


### PR DESCRIPTION
Related to https://github.com/flutter/flutter/issues/155019