### PR TITLE
fix: Fixed the Theme configuration widget's overflow issue.

### DIFF
--- a/lib/home/views/home_page.dart
+++ b/lib/home/views/home_page.dart
@@ -275,23 +275,56 @@ class _ThemeConfigs extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MyCard(
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Text(
-            'Theme configurations',
-            style: Theme.of(context).textTheme.headlineSmall,
-          ),
-          const Row(
-            children: [
-              Material3Switch(),
-              HorizontalPadding(),
-              ThemeBrightnessSwitch(),
-            ],
-          ),
-        ],
-      ),
+    return LayoutBuilder(
+      builder: (ctx, constraints) {
+        final width = constraints.maxWidth;
+
+        return MyCard(
+          child: width < 560
+              ? Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    Text(
+                      'Theme configurations',
+                      style: Theme.of(context).textTheme.headlineSmall,
+                    ),
+                    SizedBox(
+                      width: width * 0.8,
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          SizedBox(
+                            width: width * 0.3,
+                            child: Material3Switch(),
+                          ),
+                          SizedBox(
+                            width: width * 0.3,
+                            child: ThemeBrightnessSwitch(),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                )
+              : Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      'Theme configurations',
+                      style: Theme.of(context).textTheme.headlineSmall,
+                    ),
+                    Row(
+                      children: [
+                        Material3Switch(),
+                        HorizontalPadding(),
+                        ThemeBrightnessSwitch(),
+                      ],
+                    ),
+                  ],
+                ),
+        );
+      },
     );
   }
 }

--- a/lib/home/widgets/material3_switch.dart
+++ b/lib/home/widgets/material3_switch.dart
@@ -9,14 +9,28 @@ class Material3Switch extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      children: [
-        Text(
-          'Material 3',
-          style: Theme.of(context).textTheme.titleMedium,
-        ),
-        const _Switch(),
-      ],
+    return LayoutBuilder(
+      builder: (ctx, constraints) {
+        return constraints.maxWidth < 460
+            ? Column(
+                children: [
+                  Text(
+                    'Material 3',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const _Switch(),
+                ],
+              )
+            : Row(
+                children: [
+                  Text(
+                    'Material 3',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const _Switch(),
+                ],
+              );
+      },
     );
   }
 }

--- a/lib/home/widgets/theme_brightness_switch.dart
+++ b/lib/home/widgets/theme_brightness_switch.dart
@@ -9,14 +9,28 @@ class ThemeBrightnessSwitch extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      children: [
-        Text(
-          'Brightness',
-          style: Theme.of(context).textTheme.titleMedium,
-        ),
-        const _Switch(),
-      ],
+    return LayoutBuilder(
+      builder: (ctx, constraints) {
+        return constraints.maxWidth < 460
+            ? Column(
+                children: [
+                  Text(
+                    'Brightness',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const _Switch(),
+                ],
+              )
+            : Row(
+                children: [
+                  Text(
+                    'Brightness',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const _Switch(),
+                ],
+              );
+      },
     );
   }
 }


### PR DESCRIPTION
The Theme Configuration widget wasn't very responsive to the width when the window was shrank below 70% of the screen's width. The widget's children would go under the device preview widget. The issue was fixed with the help of conditional widgets and **LayoutBuilder** widget.

![problem](https://github.com/user-attachments/assets/7eff3bb9-3975-4b98-a8dd-0a57d319c5c6)
![fix](https://github.com/user-attachments/assets/d3c48f61-c0be-4cad-a3dd-e0f9fd1ab4cf)
