### PR TITLE
Fixed Ui Issues

### DIFF
--- a/lib/home/views/home_page.dart
+++ b/lib/home/views/home_page.dart
@@ -275,23 +275,67 @@ class _ThemeConfigs extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MyCard(
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Text(
-            'Theme configurations',
-            style: Theme.of(context).textTheme.headlineSmall,
-          ),
-          const Row(
-            children: [
-              Material3Switch(),
-              HorizontalPadding(),
-              ThemeBrightnessSwitch(),
-            ],
-          ),
-        ],
-      ),
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final width = constraints.maxWidth;
+        return MyCard(
+          child: (width < 420
+              ? Column(
+                  mainAxisAlignment: (width < 570
+                      ? MainAxisAlignment.spaceEvenly
+                      : MainAxisAlignment.spaceBetween),
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Theme configurations',
+                      style: Theme.of(context).textTheme.headlineSmall,
+                    ),
+                    (width < 570
+                        ? const Column(
+                            crossAxisAlignment: CrossAxisAlignment.center,
+                            children: [
+                              Material3Switch(),
+                              HorizontalPadding(),
+                              ThemeBrightnessSwitch(),
+                            ],
+                          )
+                        : const Row(
+                            children: [
+                              Material3Switch(),
+                              HorizontalPadding(),
+                              ThemeBrightnessSwitch(),
+                            ],
+                          )),
+                  ],
+                )
+              : Row(
+                  mainAxisAlignment: (width < 570
+                      ? MainAxisAlignment.spaceEvenly
+                      : MainAxisAlignment.spaceBetween),
+                  children: [
+                    Text(
+                      'Theme configurations',
+                      style: Theme.of(context).textTheme.headlineSmall,
+                    ),
+                    (width < 570
+                        ? const Column(
+                            children: [
+                              Material3Switch(),
+                              HorizontalPadding(),
+                              ThemeBrightnessSwitch(),
+                            ],
+                          )
+                        : const Row(
+                            children: [
+                              Material3Switch(),
+                              HorizontalPadding(),
+                              ThemeBrightnessSwitch(),
+                            ],
+                          )),
+                  ],
+                )),
+        );
+      },
     );
   }
 }

--- a/test/home/views/home_page_test.dart
+++ b/test/home/views/home_page_test.dart
@@ -228,4 +228,14 @@ void main() {
       },
     );
   });
+  testWidgets(
+    'check layoutWidget',
+    (tester) async {
+      await pumpApp(tester);
+      await tester.pump();
+
+      expect(find.byType(LayoutBuilder), findsOneWidget);
+      expect(find.text('Theme configurations'), findsOne);
+    },
+  );
 }


### PR DESCRIPTION
The Theme Configuration widget wasn't very responsive to the width when the window was shrank below 70% of the screen's width. The widget's children would go under the device preview widget. The issue was fixed with the help of conditional widgets and LayoutBuilder widget.
### *****The Problem*****
![problem](https://github.com/user-attachments/assets/d70bb643-80af-450c-9746-693f12666c14)

### *****The Fix*****
![Screenshot from 2025-04-15 19-38-42](https://github.com/user-attachments/assets/c01602a0-c4ff-401e-a0b0-a959da9a22df)


